### PR TITLE
Closes #18. Sets Content-Type header to application/json

### DIFF
--- a/SVHTTPRequest/SVHTTPRequest.m
+++ b/SVHTTPRequest/SVHTTPRequest.m
@@ -264,6 +264,9 @@ typedef NSUInteger SVHTTPRequestState;
     
     if(self.userAgent)
         [self.operationRequest setValue:userAgent forHTTPHeaderField:@"User-Agent"];
+
+    if (self.sendParametersAsJSON)
+        [self.operationRequest setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
     
     [self willChangeValueForKey:@"isExecuting"];
     self.state = SVHTTPRequestStateExecuting;    


### PR DESCRIPTION
If sendParametersAsJSON is YES, application/json becomes the Content-Type.
