### PR TITLE
Replaced explicit class references in class methods with 'self'

### DIFF
--- a/SVHTTPRequest/SVHTTPClient.m
+++ b/SVHTTPRequest/SVHTTPClient.m
@@ -33,14 +33,14 @@
 
 
 + (id)sharedClient {
-    return [SVHTTPClient sharedClientWithIdentifier:@"master"];
+    return [self sharedClientWithIdentifier:@"master"];
 }
 
 + (id)sharedClientWithIdentifier:(NSString *)identifier {
     SVHTTPClient *sharedClient = [[self sharedClients] objectForKey:identifier];
     
     if(!sharedClient) {
-        sharedClient = [[SVHTTPClient alloc] init];
+        sharedClient = [[self alloc] init];
         [[self sharedClients] setObject:sharedClient forKey:identifier];
     }
     


### PR DESCRIPTION
Instead of addressing the class explicitly (SVHTTPClient), class methods now call "self". 

This allows the class to be subclassed properly correctly.
