### PR TITLE
Add variants of the cancel methods that block until the operations have completed

### DIFF
--- a/SVHTTPRequest/SVHTTPClient.h
+++ b/SVHTTPRequest/SVHTTPClient.h
@@ -32,7 +32,9 @@ typedef void (^SVHTTPRequestCompletionHandler)(id response, NSHTTPURLResponse *u
 - (SVHTTPRequest*)HEAD:(NSString*)path parameters:(NSDictionary*)parameters completion:(SVHTTPRequestCompletionHandler)completionBlock;
 
 - (void)cancelRequestsWithPath:(NSString*)path;
+- (void)cancelRequestsWithPath:(NSString *)path waitUntilFinished:(BOOL)waitUntilFinished;
 - (void)cancelAllRequests;
+- (void)cancelAllRequestsAndWait;
 
 // header values common to all requests, e.g. API keys
 - (void)setValue:(NSString *)value forHTTPHeaderField:(NSString *)field;

--- a/SVHTTPRequest/SVHTTPClient.m
+++ b/SVHTTPRequest/SVHTTPClient.m
@@ -113,15 +113,29 @@
 #pragma mark - Operation Cancelling
 
 - (void)cancelRequestsWithPath:(NSString *)path {
+    [self cancelRequestsWithPath:path waitUntilFinished:NO];
+}
+
+- (void)cancelRequestsWithPath:(NSString *)path waitUntilFinished:(BOOL)waitUntilFinished {
     [self.operationQueue.operations enumerateObjectsUsingBlock:^(id request, NSUInteger idx, BOOL *stop) {
         NSString *requestPath = [request valueForKey:@"requestPath"];
-        if([requestPath isEqualToString:path])
+        if([requestPath isEqualToString:path]) {
             [request cancel];
+
+            if (waitUntilFinished) {
+                [request waitUntilFinished];
+            }
+        }
     }];
 }
 
 - (void)cancelAllRequests {
     [self.operationQueue cancelAllOperations];
+}
+
+- (void)cancelAllRequestsAndWait {
+    [self cancelAllRequests];
+    [self.operationQueue waitUntilAllOperationsAreFinished];
 }
 
 #pragma mark -


### PR DESCRIPTION
I've found this useful when running on a background thread, and needing to clear out the operation queue before pushing a new download of the same URL onto the queue.
