### PR TITLE
Use a basePath of @"", rather than nil to prevent (null) being prepended to URLs

### DIFF
--- a/SVHTTPRequest/SVHTTPClient.m
+++ b/SVHTTPRequest/SVHTTPClient.m
@@ -57,6 +57,7 @@
 - (id)init {
     if (self = [super init]) {
         self.operationQueue = [[NSOperationQueue alloc] init];
+        self.basePath = @"";
     }
     
     return self;


### PR DESCRIPTION
Fixes #29
