### PR TITLE
Redundant creation of response object

### DIFF
--- a/SVHTTPRequest/SVHTTPRequest.m
+++ b/SVHTTPRequest/SVHTTPRequest.m
@@ -499,7 +499,6 @@ static NSString *defaultUserAgent;
         
         if ([[operationURLResponse MIMEType] isEqualToString:@"application/json"]) {
             if(self.operationData && self.operationData.length > 0) {
-                response = [NSData dataWithData:self.operationData];
                 NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:response options:NSJSONReadingAllowFragments error:&error];
                 
                 if(jsonObject)


### PR DESCRIPTION
Nothing earth shattering but I noticed it while looking at adding support for decoding other response mime types.
