### PR TITLE
Fix build error "Property with 'retain (or strong)' attribute must be of object type"

### DIFF
--- a/SVHTTPRequest/SVHTTPRequest.m
+++ b/SVHTTPRequest/SVHTTPRequest.m
@@ -52,8 +52,8 @@ static NSTimeInterval SVHTTPRequestTimeoutInterval = 20;
 @property (nonatomic, assign) dispatch_queue_t saveDataDispatchQueue;
 @property (nonatomic, assign) dispatch_group_t saveDataDispatchGroup;
 #else
-@property (nonatomic, strong) dispatch_queue_t saveDataDispatchQueue;
-@property (nonatomic, strong) dispatch_group_t saveDataDispatchGroup;
+@property (nonatomic, strong) __attribute__((NSObject)) dispatch_queue_t saveDataDispatchQueue;
+@property (nonatomic, strong) __attribute__((NSObject)) dispatch_group_t saveDataDispatchGroup;
 #endif
 
 @property (nonatomic, copy) SVHTTPRequestCompletionHandler operationCompletionBlock;


### PR DESCRIPTION
I ran into this issue trying to build a new project using SVHTTPRequest (obviously) :

```
Property with 'retain (or strong)' attribute must be of object type
```

I'm not sure about this fix but it worked for me. 
I'm using XCode 4.6.3 on a brand new project targeting 6.1, if it helps...
