### PR TITLE
Fix a compatible issue under Xcode 6.1 with iOS SDK 8.1

### DIFF
--- a/SVHTTPRequest/SVHTTPRequest.m
+++ b/SVHTTPRequest/SVHTTPRequest.m
@@ -8,6 +8,7 @@
 //
 
 #import "SVHTTPRequest.h"
+#import <UIKit/UIApplication.h>
 
 @interface NSData (Base64)
 - (NSString*)base64EncodingWithLineLength:(unsigned int)lineLength;


### PR DESCRIPTION
Fix bug that build error under Xcode 6.1 with iOS 8.1 SDK, need add #import <UIKit/UIApplication.h>,
else show unknown "UIBackgroundTaskIdentifier" type.
