### PR TITLE
Fixed build error, "Property with 'retain (or strong)' attribute must be of object type"

### DIFF
--- a/SVHTTPRequest/SVHTTPRequest.m
+++ b/SVHTTPRequest/SVHTTPRequest.m
@@ -51,8 +51,8 @@ static NSTimeInterval SVHTTPRequestTimeoutInterval = 20;
 @property (nonatomic, assign) dispatch_queue_t saveDataDispatchQueue;
 @property (nonatomic, assign) dispatch_group_t saveDataDispatchGroup;
 #else
-@property (nonatomic, strong) dispatch_queue_t saveDataDispatchQueue;
-@property (nonatomic, strong) dispatch_group_t saveDataDispatchGroup;
+@property (nonatomic, strong) __attribute__((NSObject)) dispatch_queue_t saveDataDispatchQueue;
+@property (nonatomic, strong) __attribute__((NSObject)) dispatch_group_t saveDataDispatchGroup;
 #endif
 
 @property (nonatomic, copy) SVHTTPRequestCompletionHandler operationCompletionBlock;


### PR DESCRIPTION
Fixed build error, "Property with 'retain (or strong)' attribute must
be of object type", under Xcode 6.1.1 with iOS 8.1 SDK.
